### PR TITLE
Bugfix submissions fix nan mags

### DIFF
--- a/flows/tidesCom.py
+++ b/flows/tidesCom.py
@@ -282,6 +282,7 @@ def createNewTransientin4MOST(tableIn):
     catDict = row.to_dict()
     #print(catDict['name'])
     # Validate magnitude before submission; crash on NaN/invalid. Please change this if we should send NaNs as some default value
+    # Currently only on rmag, but could be extended to others if needed
     mag_raw = catDict.get('rmag')
     try:
       mag_val = float(mag_raw)


### PR DESCRIPTION
Added a few lines to tidesCom to stop NaN magnitudes being submitted. Not particularly detailed fix and set to raise an exception but can be modified easily.